### PR TITLE
fix problema de falta do arquivo indices.txt

### DIFF
--- a/arquivo/arquivo.c
+++ b/arquivo/arquivo.c
@@ -181,6 +181,10 @@ arvore carregar_arquivo_index(tabela *tab) {
 	strcpy(nome, "indices.txt");
 
 	arquivo = fopen(nome, "r+");
+	if(arquivo == NULL) {
+		arquivo = fopen(nome, "w");
+	}
+
 	fseek(arquivo, 0, SEEK_END);
 
     if(arquivo != NULL){


### PR DESCRIPTION
Evita a falha de segmentação quando rodar o codigo sem o arquivo indices.txt existir